### PR TITLE
fix: landing page horizontal scroll

### DIFF
--- a/packages/landing/components/molecules/IntroSectionImages/index.tsx
+++ b/packages/landing/components/molecules/IntroSectionImages/index.tsx
@@ -39,7 +39,7 @@ const IntroPeopleImage = () => (
     <View
       position="absolute"
       top="656px"
-      right="-49px"
+      right="0px"
       width="305px"
       height="405pxx"
       overflow="hidden"

--- a/packages/landing/components/molecules/PersonCard/index.tsx
+++ b/packages/landing/components/molecules/PersonCard/index.tsx
@@ -31,7 +31,7 @@ const PersonCard = ({ item }: IPersonCardProps) => {
         height: '223px',
         borderRadius: '30px',
         position: 'relative',
-        margin: '15px',
+        margin: '10px',
       }}
       // // the `as any` come from the fact of Typescript
       // // and the event handlers

--- a/packages/landing/components/organisms/BannerSection/index.tsx
+++ b/packages/landing/components/organisms/BannerSection/index.tsx
@@ -14,7 +14,7 @@ const AboutPOISection = () => {
   return (
     <VStack alignItems="center" position="relative">
       <Element name={BANNER_SECTION} />
-      <Images.Banner />
+      <Images.Banner width="100%" />
       <View position="absolute">
         <Heading
           mt="12"


### PR DESCRIPTION
This pull request aims to remove the horizontal scroll bar from the landing page, it may brake on screens with less than 1366px width resolution (this was the smallest screen tested with the following changes).