### PR TITLE
feat: apply border radius on landing page buttons

### DIFF
--- a/packages/landing/components/atoms/NavigationTools/index.tsx
+++ b/packages/landing/components/atoms/NavigationTools/index.tsx
@@ -38,7 +38,7 @@ const NavigationTools = () => {
           {text}
         </Button>
       ))}
-      <Button variant="solid" onPress={() => {}}>
+      <Button variant="solid" borderRadius={3000} onPress={() => {}}>
         {t(keys.toolbar.goToApp)}
       </Button>
     </>

--- a/packages/landing/components/organisms/IntroSection/index.tsx
+++ b/packages/landing/components/organisms/IntroSection/index.tsx
@@ -18,7 +18,7 @@ const IntroSection = () => {
         </Heading>
         <Text mt="16">{t(keys.introSection.subTitle.firstSection)}</Text>
         <Text mt="5">{t(keys.introSection.subTitle.secondSection)}</Text>
-        <Button colorScheme="primary" variant="solid">
+        <Button colorScheme="primary" variant="solid" borderRadius="3000px" w="40%" mt="5">
           {t(keys.introSection.donateCTA)}
         </Button>
       </VStack>


### PR DESCRIPTION
This pull request aims to apply rounded corners on "Go to App" and "donate" buttons that were not matching the standard value (3000px), also it fixes the donate button width within the intro section (should not be 100%).